### PR TITLE
MySQL localhost로 연결해야 됨

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -3,13 +3,7 @@ server.address=0.0.0.0
 server.port=8081
 
 # MySQL ?? (local)
-#spring.datasource.url=jdbc:mysql://localhost:3306/dolai
-#spring.datasource.username=root
-#spring.datasource.password=1234
-#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-
-# MySQL ?? (deploy)
-spring.datasource.url=jdbc:mysql://mysql-container:3306/dolai
+spring.datasource.url=jdbc:mysql://localhost:3306/dolai
 spring.datasource.username=root
 spring.datasource.password=1234
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
✅ 왜 이런 일이 생겼는가?
당신의 application.properties에는 다음과 같은 설정이 있습니다:

properties
`spring.datasource.url=jdbc:mysql://mysql-container:3306/dolai`
이 설정은 Docker Compose 네트워크 안에서만 동작합니다.

그러나 현재:

백엔드 서버는 Docker 밖에서 직접 실행 중

Docker 네트워크에 정의된 mysql-container를 호스트 이름으로 해석 못 함

→ 그래서 DNS 오류 UnknownHostException.