### PR TITLE
⚡️ Docker restart 정책 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
     build:
       context: ./mediasoup-sfu
       dockerfile: Dockerfile
+    restart: always
     container_name: mediasoup-server
     ports:
       - "4443:4443"           # Mediasoup signaling


### PR DESCRIPTION
Docker 컨테이너가 crash되거나 mediasoup worker died 등으로 프로세스가 종료될 경우 자동으로 재시작되도록 설정하는 게 매우 중요